### PR TITLE
Add non-existed link for this check method test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 
 sudo: false
 
@@ -10,8 +11,7 @@ matrix:
   fast_finish: true
 
 before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar install --dev --no-interaction
+  - composer install --no-interaction
 
 script:
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 		"nkey/phpgenerics" : "dev-master"
 	},
 	"require-dev" : {
-		"phpunit/phpunit" : "~6.3",
-		"scrutinizer/ocular" : "~1.4"
+		"phpunit/phpunit" : "^6.3",
+		"scrutinizer/ocular" : "^1.4"
 	}
 }

--- a/src/LinkCheckProvider.php
+++ b/src/LinkCheckProvider.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of Nkey/LinkCheck package
- * 
+ *
  * @package Nkey\LinkCheck
  */
 namespace Nkey\LinkCheck;
@@ -15,7 +15,7 @@ use Generics\Streams\OutputStream;
 
 /**
  * This class provides the link checking functionality.
- * 
+ *
  * @author Maik Greubel <greubel@nkey.de>
  */
 class LinkCheckProvider
@@ -41,7 +41,7 @@ class LinkCheckProvider
 
     /**
      * Create a new instance of LinkCheckProvider
-     * 
+     *
      * @param Url $url
      *            The url to check
      */
@@ -51,10 +51,10 @@ class LinkCheckProvider
         $this->output = new StandardOutputStream();
         $this->url = $url;
     }
-    
+
     /**
      * Override the standard output stream using a custom output stream instance
-     * 
+     *
      * @param OutputStream $stream
      */
     public function setOutput(OutputStream $stream)
@@ -74,44 +74,44 @@ class LinkCheckProvider
     public function check(array $options = array())
     {
         $this->httpClient->request('GET');
-        
+
         if ($this->httpClient->getResponseCode() != 200) {
             $this->output->write("Invalid response code " . $this->httpClient->getResponseCode());
             return;
         }
-        
+
         $response = "";
         $size = $this->httpClient->getPayload()->count();
         if (isset($this->httpClient->getHeaders()['Content-Length'])) {
             $size = $this->httpClient->getHeaders()['Content-Length'];
         }
-        
+
         while ($this->httpClient->getPayload()->ready()) {
             $response .= $this->httpClient->getPayload()->read($size);
         }
-        
+
         $this->extractAndCheckUrls($response, $options);
     }
 
     private function extractAndCheckUrls(string $response, array $options)
     {
         $matches = [];
-        
+
         if (preg_match_all('#<a href="([^\"]*)">#', $response, $matches)) {
             array_shift($matches);
             $matches = $matches[0];
         }
-        
+
         if (count($matches) == 0) {
             return;
         }
-        
+
         foreach ($matches as $match) {
             if (substr($match, 0, 4) != 'http') {
                 $match = sprintf("%s://%s:%d%s", $this->url->getScheme(), $this->url->getAddress(), $this->url->getPort(), $match);
             }
             $url = UrlParser::parseUrl($match);
-            
+
             $this->output->write($url);
             if ($url->getAddress() == $this->url->getAddress()) {
                 $this->checkSameSiteurl($url, $options);

--- a/tests/LinkCheckProviderTest.php
+++ b/tests/LinkCheckProviderTest.php
@@ -9,20 +9,31 @@ use Generics\Streams\Interceptor\CachedStreamInterceptor;
 
 class LinkCheckProviderTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function testSimple()
+    public function testCheckOnExistedLink()
     {
         $provider = new LinkCheckProvider(UrlParser::parseUrl("https://letsencrypt.org/getting-started/"));
-        
+
         $stream = new StandardOutputStream();
         $interceptor = new CachedStreamInterceptor();
         $stream->setInterceptor($interceptor);
         $provider->setOutput($stream);
-        
+
         $provider->check();
-        
+
         $this->assertContains("https://letsencrypt.org/privacy/ OK", $interceptor->getCache());
+    }
+
+    public function testCheckOnNonExistedLink()
+    {
+        $provider = new LinkCheckProvider(UrlParser::parseUrl("https://letsencrypt.org/123456"));
+
+        $stream = new StandardOutputStream();
+        $interceptor = new CachedStreamInterceptor();
+        $stream->setInterceptor($interceptor);
+        $provider->setOutput($stream);
+
+        $provider->check();
+
+        $this->assertContains("Invalid response code 404", $interceptor->getCache());
     }
 }


### PR DESCRIPTION
# Changed log
- Test enhancement.
- Remove `test` annotation because the prefix-based `test` method is used.
- Download `composer.phar` is not necessary in Travis CI build because the `composer` has been already existed in CI build.